### PR TITLE
Add request binary dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,11 @@ A [fastapi](https://fastapi.tiangolo.com/) app for testing HTTP/REST clients.
 ### Canned json
 
 You may want to craft custom json for usage with endpoints like `get` and `match`:
-1. Make a copy of the [bin/response/sample](bin/response/sample) directory, with a meaningful name
-2. Update the `payload.json` file to reflect the json payload to be returned and/or matched
-3. Update or remove the `headers.json` file to reflect the headers to be returned and/or matched
+1. Make a copy of the proper directory, using a meaningful name in place of `sample`:
+    * Requests: [bin/response/sample](bin/request/sample)
+    * Responses:  [bin/response/sample](bin/response/sample)
+2. Upload the new `payload.json` file to reflect the json payload to be returned and/or matched
+3. Update or remove the new `headers.json` file to reflect the headers to be returned and/or matched
 
 ## Running
 
@@ -70,7 +72,7 @@ A list of mismatches (or lack thereof) is returned as JSON.
 The [pytest](https://pypi.org/project/pytest/) tests in [test/pytest](test/pytest) can be executed using the pytest library.
 
 If this app was properly installed, so was pytest!
-Simply execute `pytest` in the project's directory and the tests will be run.
+Simply execute `pytest` in the project's directory (with the virtual environment activated) and the tests will be run.
 
 ## Karate
 The [karate](https://karatelabs.github.io/karate/) tests in [test/karate](test/karate) can be executed using a karate executable.

--- a/bin/request/sample/headers.json
+++ b/bin/request/sample/headers.json
@@ -1,1 +1,1 @@
-{"content-type":"application/json","myHeader":"myValue"}
+{"content-type":"application/json","myHeader":"myRequestHeaderValue"}

--- a/bin/request/sample/headers.json
+++ b/bin/request/sample/headers.json
@@ -1,0 +1,1 @@
+{"content-type":"application/json","myHeader":"myValue"}

--- a/bin/request/sample/payload.json
+++ b/bin/request/sample/payload.json
@@ -1,0 +1,1 @@
+{"status":"new", "items":["one","two","three"],"data":"foo"}

--- a/bin/request/sample/payload.json
+++ b/bin/request/sample/payload.json
@@ -1,1 +1,1 @@
-{"status":"new", "items":["one","two","three"],"data":"foo"}
+{"status":"new", "items":["one","two","three"],"data":"bar"}

--- a/routes/cannedjson_routes.py
+++ b/routes/cannedjson_routes.py
@@ -24,7 +24,7 @@ def get_json(name: str, request: Request):
     except Exception as e:
         print(str(e))
         return JSONResponse(
-            content=f"Content not found for name: {name} - {e}",
+            content=f"Response Content not found for name: {name} - {e}",
             status_code=status.HTTP_404_NOT_FOUND,
         )
 
@@ -39,11 +39,11 @@ async def match_json(name, request: Request):
     """
 
     try:
-        canned_data: CannedJson = load_cannedjson(name)
+        canned_data: CannedJson = load_cannedjson(name, True)
     except Exception as e:
         print(e)
         return JSONResponse(
-            content=f"Content not found for name: {name}",
+            content=f"Request Content not found for name: {name}",
             status_code=status.HTTP_404_NOT_FOUND,
         )
 

--- a/test/karate/sample.feature
+++ b/test/karate/sample.feature
@@ -35,6 +35,7 @@ Feature: The basic endpoints
     Given url 'http://localhost:8000/json/sample'
     When method get
     Then status 200
+    And match header myHeader == "myValue"
     And match response == 
     """
    { 
@@ -50,8 +51,8 @@ Feature: The basic endpoints
 
   Scenario Outline: matching a request
     Given url 'http://localhost:8000/match/sample'
-    And request {"status":"new", "items":["one","two","three"],"data":"foo"}
-    And headers {"content-type":"application/json","myHeader":"myValue"}
+    And request {"status":"new", "items":["one","two","three"],"data":"bar"}
+    And headers {"content-type":"application/json","myHeader":"myRequestHeaderValue"}
     When method <METHOD>
     Then status 200
     And assert response.status == 'passed'

--- a/utils/jsonloader.py
+++ b/utils/jsonloader.py
@@ -7,8 +7,10 @@ _base_dir = dirname(dirname(realpath(__file__)))
 _bin_dir = realpath(f"{_base_dir}/bin")
 
 
-def load_cannedjson(name: str) -> CannedJson:
-    dir = realpath(f"{_bin_dir}/response/{name}")
+def load_cannedjson(name: str, request: bool = False) -> CannedJson:
+
+    direction = 'request' if request else 'response'
+    dir = realpath(f"{_bin_dir}/{direction}/{name}")
 
     payload_file_name = realpath(f"{dir}/payload.json")
     payload_file = open(payload_file_name)


### PR DESCRIPTION
Stop using the `bin/response` directory when working on request data. Uses the new 'bin/request' directory instead.