### PR TITLE
Issue 28 - remove requirement of cloud cli

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi[standard]==0.135.2
+fastapi[standard-no-fastapi-cloud-cli]==0.135.2
 pydantic==2.12.5
 
 pytest==9.0.2


### PR DESCRIPTION
See https://github.com/jhoule86/fastapi_sandbox/issues/28

Updating the requirements to not require the `fastapi-cloud-cli` as that package is not available in secure environments because it could accidentally or purposely be used to deploy to a third-party site.